### PR TITLE
Fixed namespace traversal for model's image field

### DIFF
--- a/ux/touch/ImageGridList/view/List.js
+++ b/ux/touch/ImageGridList/view/List.js
@@ -144,12 +144,12 @@ Ext.define('Ext.ux.touch.ImageGridList.view.List', {
         var me = this,
             nameSpace = me.getUrlNameSpace().split('.'),
             data = model.data,
-            key,
-            url;
+            key = nameSpace[0],
+            url = data[key];
 
         for(var i = 0, length = nameSpace.length; i < length; i++){
             key = nameSpace[i];
-            url = data[key];
+            url = url[key];
         }
 
         return url;


### PR DESCRIPTION
If our model's image is nested deeper than the first level:

{
  'image_thumb': {
    'url': 'http://...',
    //...
  }
}

We want to be able to tell it to ImageGridList like this:

var me = this,
    gallery = me.down('image-grid-list-panel'),
    list = gallery.down('image-grid-list');
list.setUrlNameSpace('image_thumb.url');

So this commit fixes the object traversal.
